### PR TITLE
Up sidekiq dependency to version 7

### DIFF
--- a/sidekiq-amigo.gemspec
+++ b/sidekiq-amigo.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     sidekiq-amigo provides a pubsub system and other enhancements around Sidekiq.
   DESC
   s.files = Dir["lib/**/*.rb"]
-  s.add_runtime_dependency("sidekiq", "~> 6")
+  s.add_runtime_dependency("sidekiq", "~> 7")
   s.add_runtime_dependency("sidekiq-cron", "~> 1")
   s.add_development_dependency("platform-api", "> 0")
   s.add_development_dependency("rack", "~> 2.2")


### PR DESCRIPTION
In order to upgrade sidekiq to version 7, we need to update the dependency version to avoid conflicts. This change will be tested for compatibility issues in another application.