### PR TITLE
Sidekiq v7 support

### DIFF
--- a/lib/amigo.rb
+++ b/lib/amigo.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "redis"
+require "redis-client"
 require "sidekiq"
 require "sidekiq-cron"
 

--- a/lib/amigo/retry.rb
+++ b/lib/amigo/retry.rb
@@ -83,6 +83,8 @@ module Amigo
     end
 
     class ServerMiddleware
+      include Sidekiq::ServerMiddleware
+
       def call(worker, job, _queue)
         yield
       rescue Amigo::Retry::Retry => e

--- a/lib/amigo/spec_helpers.rb
+++ b/lib/amigo/spec_helpers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "amigo"
-require "sidekiq/worker"
+require "sidekiq/job"
 
 module Amigo
   module SpecHelpers
@@ -256,11 +256,11 @@ module Amigo
     # This allows those arbitrary job payload fields
     # to be included when the job is run.
     module_function def sidekiq_perform_inline(klass, args, item=nil)
-      Sidekiq::Worker::Setter.override_item = item
+      Sidekiq::Job::Setter.override_item = item
       begin
         klass.perform_inline(*args)
       ensure
-        Sidekiq::Worker::Setter.override_item = nil
+        Sidekiq::Job::Setter.override_item = nil
       end
     end
 

--- a/spec/amigo/autoscaler_spec.rb
+++ b/spec/amigo/autoscaler_spec.rb
@@ -272,17 +272,17 @@ RSpec.describe Amigo::Autoscaler do
   end
 
   it "can delete its persisted fields" do
-    expect(Sidekiq.redis(&:keys)).to be_empty
+    expect(Sidekiq.redis { |r| r.keys("*") }).to be_empty
     expect(Sidekiq::Queue).to receive(:all).and_return([fake_q("x", 1), fake_q("y", 20)])
     o = instance
     expect(o).to receive(:alert_test).with({"y" => 20}, duration: 0, depth: 1)
     o.setup
     o.check
-    expect(Sidekiq.redis(&:keys)).to contain_exactly(
+    expect(Sidekiq.redis { |r| r.keys("*") }).to contain_exactly(
       "amigo/autoscaler/depth", "amigo/autoscaler/last_alerted", "amigo/autoscaler/latency_event_started",
     )
     o.unpersist
-    expect(Sidekiq.redis(&:keys)).to be_empty
+    expect(Sidekiq.redis { |r| r.keys("*") }).to be_empty
   end
 
   describe "Heroku" do
@@ -317,7 +317,7 @@ RSpec.describe Amigo::Autoscaler do
       expect(reqinfo).to have_been_made
       expect(requp).to have_been_made
       expect(reqdown).to have_been_made
-      expect(Sidekiq.redis(&:keys)).to_not include("amigo/autoscaler/heroku/active_event_initial_workers")
+      expect(Sidekiq.redis { |r| r.keys("*") }).to_not include("amigo/autoscaler/heroku/active_event_initial_workers")
     end
 
     it "does not scale if initial workers are 0" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,11 +49,3 @@ RSpec.configure do |config|
     Amigo.reset_logging
   end
 end
-
-# See https://github.com/mperham/sidekiq/issues/5510
-# Once it's fixed we can remove.
-class String
-  def constantize
-    return Sidekiq::Testing.constantize(self)
-  end
-end


### PR DESCRIPTION
Sidekiq v7 brings major changes,

Fixes included are:
- The redis client gem is now required through 'redis-client' instead of 'redis'
- `Sidekiq::Worker` is now `Sidekiq::Job`, import it and use it correctly
- Custom server middleware must include `Sidekiq::ServerMiddleware`
- Remove monkeypatched `String#constantize` method, [fixed in v7](https://github.com/mperham/sidekiq/issues/5510)
- Redis `.keys` method must pass in a 'pattern' param, defaulted to `"*"`